### PR TITLE
Fix missing YAML constant bug

### DIFF
--- a/lib/whatsup/collectors.rb
+++ b/lib/whatsup/collectors.rb
@@ -1,3 +1,5 @@
+require "yaml"
+
 module Whatsup::Collectors
   class ResqueStatus
     def call

--- a/lib/whatsup/version.rb
+++ b/lib/whatsup/version.rb
@@ -1,3 +1,3 @@
 module Whatsup
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
When using this gem with a Rack application and `Bundler.setup' instead of`Bundler.require' a explicit require of the YAML gem is required.
